### PR TITLE
Funding Pot v1 Create and Edit Rounds Implementation

### DIFF
--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -63,6 +63,16 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
 
     // State
+
+    /// @notice Payment token.
+    IERC20 internal _paymentToken;
+
+    /// @notice Stores all funding rounds by their unique ID.
+    mapping(uint64 => Round) public rounds;
+
+    /// @notice The next available round ID.
+    uint64 private nextRoundId;
+
     /// @notice Storage gap for future upgrades.
     uint[50] private __gap;
 
@@ -100,6 +110,108 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
     // Public - Mutating
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function createRound(
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (uint64) {
+        if (_roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        if (_roundEnd <= _roundStart && _roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        uint64 roundId = nextRoundId;
+        rounds[roundId] = Round({
+            roundStart: _roundStart,
+            roundEnd: _roundEnd,
+            roundCap: _roundCap,
+            hookContract: _hookContract,
+            hookFunction: _hookFunction,
+            closureMechanism: _closureMechanism,
+            globalAccumulativeCaps: _globalAccumulativeCaps,
+            isActive: true
+        });
+
+        nextRoundId++;
+
+        emit RoundCreated(
+            roundId,
+            _roundStart,
+            _roundEnd,
+            _roundCap,
+            _hookContract,
+            _closureMechanism,
+            _globalAccumulativeCaps
+        );
+
+        return roundId;
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function editRound(
+        uint64 _roundId,
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (bool) {
+        Round storage round = rounds[_roundId];
+
+        if (round.roundStart == 0) {
+            revert Module__LM_PC_FundingPot__RoundDoesNotExist();
+        }
+
+        if (block.timestamp >= round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
+        }
+
+        if (_roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        if (_roundEnd <= _roundStart && _roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        round.roundStart = _roundStart;
+        round.roundEnd = _roundEnd;
+        round.roundCap = _roundCap;
+        round.hookContract = _hookContract;
+        round.hookFunction = _hookFunction;
+        round.closureMechanism = _closureMechanism;
+        round.globalAccumulativeCaps = _globalAccumulativeCaps;
+
+        emit RoundEdited(
+            _roundId,
+            _roundStart,
+            _roundEnd,
+            _roundCap,
+            _hookContract,
+            _closureMechanism,
+            _globalAccumulativeCaps
+        );
+
+        return true;
+    }
     // -------------------------------------------------------------------------
     // Internal
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -68,7 +68,7 @@ contract LM_PC_FundingPot_v1 is
     IERC20 internal _paymentToken;
 
     /// @notice Stores all funding rounds by their unique ID.
-    mapping(uint64 => Round) public rounds;
+    mapping(uint64 => Round) private rounds;
 
     /// @notice The next available round ID.
     uint64 private nextRoundId;
@@ -107,6 +107,20 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
     // Public - Getters
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundDetails(uint64 _roundId)
+        external
+        view
+        returns (Round memory)
+    {
+        return rounds[_roundId];
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundCount() external view returns (uint64) {
+        return nextRoundId;
+    }
+
     // -------------------------------------------------------------------------
     // Public - Mutating
 
@@ -119,18 +133,14 @@ contract LM_PC_FundingPot_v1 is
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external returns (uint64) {
-        if (_roundStart <= block.timestamp) {
-            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
-        }
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
+        bool _isActive;
+        // @note: This logic is required if start time is set to block.timestamp
+        // if (_roundStart == block.timestamp) {
+        //     _isActive = true;
+        // }
 
-        if (_roundEnd <= _roundStart && _roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
-        }
-
-        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
-            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
-        }
+        nextRoundId++;
 
         uint64 roundId = nextRoundId;
         rounds[roundId] = Round({
@@ -141,10 +151,10 @@ contract LM_PC_FundingPot_v1 is
             hookFunction: _hookFunction,
             closureMechanism: _closureMechanism,
             globalAccumulativeCaps: _globalAccumulativeCaps,
-            isActive: true
+            isActive: _isActive
         });
 
-        nextRoundId++;
+        _validateRoundParameters(rounds[roundId]);
 
         emit RoundCreated(
             roundId,
@@ -169,27 +179,15 @@ contract LM_PC_FundingPot_v1 is
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external returns (bool) {
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (bool) {
         Round storage round = rounds[_roundId];
 
         if (round.roundStart == 0) {
-            revert Module__LM_PC_FundingPot__RoundDoesNotExist();
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        if (block.timestamp >= round.roundStart) {
+        if (block.timestamp > round.roundStart || round.isActive) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
-        }
-
-        if (_roundStart <= block.timestamp) {
-            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
-        }
-
-        if (_roundEnd <= _roundStart && _roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
-        }
-
-        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
-            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
         }
 
         round.roundStart = _roundStart;
@@ -199,6 +197,8 @@ contract LM_PC_FundingPot_v1 is
         round.hookFunction = _hookFunction;
         round.closureMechanism = _closureMechanism;
         round.globalAccumulativeCaps = _globalAccumulativeCaps;
+
+        _validateRoundParameters(round);
 
         emit RoundEdited(
             _roundId,
@@ -214,4 +214,38 @@ contract LM_PC_FundingPot_v1 is
     }
     // -------------------------------------------------------------------------
     // Internal
+
+    /// @notice Validates the round parameters.
+    /// @param  round The round to validate.
+    /// @dev    Reverts if the round parameters are invalid.
+    function _validateRoundParameters(Round memory round) internal view {
+        // Validate round start time is in the future
+        // @note: The below condition wont allow _roundStart == block.timestamp
+        // @note: If we allow if then _isActive should be set to true
+        if (round.roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        // Validate that either end time or cap is set
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        // If end time is set, validate it's after start time
+        if (round.roundEnd > 0 && round.roundEnd <= round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        // Validate hook contract and function consistency
+        if (round.hookContract != address(0) && round.hookFunction.length == 0)
+        {
+            revert
+                Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract();
+        }
+
+        if (round.hookContract == address(0) && round.hookFunction.length > 0) {
+            revert
+                Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
+        }
+    }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -21,6 +21,27 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Upgradeable} from
     "@oz-up/utils/introspection/ERC165Upgradeable.sol";
 
+/**
+ * @title   Inverter Funding Pot Module
+ *
+ * @notice  The module allows project supporters to contribute during funding rounds.
+ *
+ * @dev     Extends {ERC20PaymentClientBase_v2} and implements {ILM_PC_FundingPot_v1}.
+ *          This contract manages funding rounds with configurable parameters including
+ *          start/end times, funding caps, and hook contracts for custom logic.
+ *          Uses timestamps as flags for payment processing via FLAG_START, FLAG_CLIFF,
+ *          and FLAG_END constants.
+ *
+ * @custom:security-contact security@inverter.network
+ *                          In case of any concerns or findings, please refer to our Security Policy
+ *                          at security.inverter.network or email us directly!
+ *
+ * @custom:version  v1.0.0
+ *
+ * @custom:inverter-standard-version    v0.1.0
+ *
+ * @author  Inverter Network
+ */
 contract LM_PC_FundingPot_v1 is
     ILM_PC_FundingPot_v1,
     ERC20PaymentClientBase_v2
@@ -63,9 +84,6 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
 
     // State
-
-    /// @notice Payment token.
-    IERC20 internal _paymentToken;
 
     /// @notice Stores all funding rounds by their unique ID.
     mapping(uint64 => Round) private rounds;
@@ -175,7 +193,7 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (bool) {
         Round storage round = rounds[_roundId];
 
-        if (round.roundStart == 0) {
+        if (round.roundEnd == 0 && round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -134,12 +134,6 @@ contract LM_PC_FundingPot_v1 is
         bool _closureMechanism,
         bool _globalAccumulativeCaps
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
-        bool _isActive;
-        // @note: This logic is required if start time is set to block.timestamp
-        // if (_roundStart == block.timestamp) {
-        //     _isActive = true;
-        // }
-
         nextRoundId++;
 
         uint64 roundId = nextRoundId;
@@ -150,8 +144,7 @@ contract LM_PC_FundingPot_v1 is
             hookContract: _hookContract,
             hookFunction: _hookFunction,
             closureMechanism: _closureMechanism,
-            globalAccumulativeCaps: _globalAccumulativeCaps,
-            isActive: _isActive
+            globalAccumulativeCaps: _globalAccumulativeCaps
         });
 
         _validateRoundParameters(rounds[roundId]);
@@ -186,7 +179,7 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        if (block.timestamp > round.roundStart || round.isActive) {
+        if (block.timestamp > round.roundStart) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
         }
 
@@ -221,7 +214,6 @@ contract LM_PC_FundingPot_v1 is
     function _validateRoundParameters(Round memory round) internal view {
         // Validate round start time is in the future
         // @note: The below condition wont allow _roundStart == block.timestamp
-        // @note: If we allow if then _isActive should be set to true
         if (round.roundStart <= block.timestamp) {
             revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
         }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -6,15 +6,136 @@ import {IERC20PaymentClientBase_v2} from
     "@lm/interfaces/IERC20PaymentClientBase_v2.sol";
 
 interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
-// -------------------------------------------------------------------------
-// Events
+    //--------------------------------------------------------------------------
+    // Structs
 
-// -------------------------------------------------------------------------
-// Errors
+    /// @notice Struct used to store information about a funding round.
+    /// @param roundStart Timestamp indicating when the round starts.
+    /// @param roundEnd Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
+    /// @param roundCap Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
+    /// @param hookContract Address of an optional hook contract to be called after round closure.
+    /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
+    /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
+    /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
+    /// @param isActive Indicates whether the round is currently active.
+    struct Round {
+        uint roundStart;
+        uint roundEnd;
+        uint roundCap;
+        address hookContract;
+        bytes hookFunction;
+        bool closureMechanism;
+        bool globalAccumulativeCaps;
+        bool isActive;
+    }
 
-// -------------------------------------------------------------------------
-// Public - Getters
+    // -------------------------------------------------------------------------
+    // Events
 
-// -------------------------------------------------------------------------
-// Public - Mutating
+    /// @notice Emitted when a new round is created.
+    /// @dev This event signals the creation of a new round with specific parameters.
+    /// @param roundId The unique identifier for the round.
+    /// @param roundStart The timestamp when the round starts.
+    /// @param roundEnd The timestamp when the round ends.
+    /// @param roundCap The maximum allocation or cap for the round.
+    /// @param hookContract The address of an optional hook contract for custom logic.
+    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    event RoundCreated(
+        uint indexed roundId,
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    );
+
+    /// @notice Emitted when an existing round is edited.
+    /// @dev This event signals modifications to an existing round's parameters.
+    /// @param roundId The unique identifier of the round being edited.
+    /// @param roundStart The updated timestamp for when the round starts.
+    /// @param roundEnd The updated timestamp for when the round ends.
+    /// @param roundCap The updated maximum allocation or cap for the round.
+    /// @param hookContract The address of an optional hook contract for custom logic.
+    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    event RoundEdited(
+        uint indexed roundId,
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    );
+
+    // -------------------------------------------------------------------------
+    // Errors
+
+    /// @notice Amount can not be zero.
+    error Module__LM_PC_FundingPot__InvalidDepositAmount();
+
+    /// @notice Round does not exist
+    error Module__LM_PC_FundingPot__RoundDoesNotExist();
+
+    /// @notice Round start time must be in the future
+    error Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+
+    /// @notice Round must have either an end time or a funding cap
+    error Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+
+    /// @notice Round end time must be after round start time
+    error Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+
+    /// @notice Round has already started and cannot be modified
+    error Module__LM_PC_FundingPot__RoundAlreadyStarted();
+
+    // -------------------------------------------------------------------------
+    // Public - Getters
+
+    // -------------------------------------------------------------------------
+    // Public - Mutating
+
+    /// @notice Creates a new funding round
+    /// @dev Only callable by funding pot admin
+    /// @param _roundStart Start timestamp for the round
+    /// @param _roundEnd End timestamp for the round (0 if using roundCap only)
+    /// @param _roundCap Maximum contribution cap in collateral tokens (0 if using roundEnd only)
+    /// @param _hookContract Address of contract to call after round closure
+    /// @param _hookFunction Encoded function call for the hook
+    /// @param _closureMechanism Whether hook closure coincides with contribution span end
+    /// @param _globalAccumulativeCaps Whether caps accumulate globally
+    /// @return The ID of the newly created round
+    function createRound(
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (uint64);
+
+    /// @notice Edits an existing funding round
+    /// @dev Only callable by funding pot admin and only before the round has started
+    /// @param _roundId ID of the round to edit
+    /// @param _roundStart New start timestamp
+    /// @param _roundEnd New end timestamp
+    /// @param _roundCap New maximum contribution cap
+    /// @param _hookContract New hook contract address
+    /// @param _hookFunction New encoded function call
+    /// @param _closureMechanism New closure mechanism setting
+    /// @param _globalAccumulativeCaps New global accumulative caps setting
+    /// @return True if edit was successful
+    function editRound(
+        uint64 _roundId,
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (bool);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -26,7 +26,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes hookFunction;
         bool closureMechanism;
         bool globalAccumulativeCaps;
-        bool isActive;
+        bool isActive; //@note: do we need this?
     }
 
     // -------------------------------------------------------------------------
@@ -91,8 +91,32 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Round has already started and cannot be modified
     error Module__LM_PC_FundingPot__RoundAlreadyStarted();
 
+    /// @notice Hook function is required when a hook contract is provided
+    error Module__LM_PC_FundingPot__HookFunctionRequiredWithContract();
+
+    /// @notice Thrown when a hook contract is specified without a hook function.
+    error Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract();
+
+    /// @notice Thrown when a hook function is specified without a hook contract.
+    error Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
+
+    /// @notice Round does not exist
+    error Module__LM_PC_FundingPot__RoundNotCreated();
+
     // -------------------------------------------------------------------------
     // Public - Getters
+
+    /// @notice Retrieves the details of a specific funding round.
+    /// @param _roundId The unique identifier of the round to retrieve.
+    /// @return A struct containing the round's details.
+    function getRoundDetails(uint64 _roundId)
+        external
+        view
+        returns (Round memory);
+
+    /// @notice Retrieves the total number of funding rounds.
+    /// @return The total number of funding rounds.
+    function getRoundCount() external view returns (uint64);
 
     // -------------------------------------------------------------------------
     // Public - Mutating

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -17,7 +17,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
     /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
     /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
-    /// @param isActive Indicates whether the round is currently active.
     struct Round {
         uint roundStart;
         uint roundEnd;
@@ -26,7 +25,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes hookFunction;
         bool closureMechanism;
         bool globalAccumulativeCaps;
-        bool isActive; //@note: do we need this?
     }
 
     // -------------------------------------------------------------------------

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -290,6 +290,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address user_
     ) public {
         testCreateRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
             address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
@@ -302,7 +305,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.Round memory editedRound =
             _helper_createEditedRoundParams();
 
-        _helper_callEditRound(0, editedRound);
+        _helper_callEditRound(roundId, editedRound);
         vm.stopPrank();
     }
 
@@ -481,36 +484,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.Round memory updatedRound =
             fundingPot.getRoundDetails(lastRoundId);
 
-        assertEq(
-            updatedRound.roundStart,
-            editedRound.roundStart,
-            "roundStart not updated"
-        );
-        assertEq(
-            updatedRound.roundEnd, editedRound.roundEnd, "roundEnd not updated"
-        );
-        assertEq(
-            updatedRound.roundCap, editedRound.roundCap, "roundCap not updated"
-        );
-        assertEq(
-            updatedRound.hookContract,
-            editedRound.hookContract,
-            "hookContract not updated"
-        );
+        assertEq(updatedRound.roundStart, editedRound.roundStart);
+        assertEq(updatedRound.roundEnd, editedRound.roundEnd);
+        assertEq(updatedRound.roundCap, editedRound.roundCap);
+        assertEq(updatedRound.hookContract, editedRound.hookContract);
         assertEq(
             keccak256(updatedRound.hookFunction),
-            keccak256(editedRound.hookFunction),
-            "hookFunction not updated"
+            keccak256(editedRound.hookFunction)
         );
-        assertEq(
-            updatedRound.closureMechanism,
-            editedRound.closureMechanism,
-            "closureMechanism not updated"
-        );
+        assertEq(updatedRound.closureMechanism, editedRound.closureMechanism);
         assertEq(
             updatedRound.globalAccumulativeCaps,
-            editedRound.globalAccumulativeCaps,
-            "globalAccumulativeCaps not updated"
+            editedRound.globalAccumulativeCaps
         );
     }
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity 0.8.23;
 
 // Internal
 import {
@@ -8,12 +8,11 @@ import {
     IOrchestrator_v1
 } from "test/modules/ModuleTest.sol";
 import {OZErrors} from "test/utils/errors/OZErrors.sol";
-import {ERC20Mock} from "test/utils/mocks/ERC20Mock.sol";
 
 // External
 import {Clones} from "@oz/proxy/Clones.sol";
 
-// Tests and Mocks
+// Mocks
 import {
     IERC20PaymentClientBase_v2,
     ERC20PaymentClientBaseV2Mock,
@@ -67,7 +66,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Initiate the Logic Module with the metadata and config data
         fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
 
-        // Give test contract the DEPOSIT_ADMIN_ROLE.
+        // Give test contract the FUNDING_POT_ROLE.
         fundingPot.grantModuleRole(
             fundingPot.FUNDING_POT_ADMIN_ROLE(), address(this)
         );
@@ -101,30 +100,37 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
-    /* Test createRound()
+    /* Test fuzzed createRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round start time is in the past
+    └── Given user has FUNDING_POT_ADMIN_ROLE
+    ├── And round start < block.timestamp
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round end time is 0 and round cap is 0
+    ├── And round end time == 0 
+    │   ├── And round cap == 0
+    │   │   └── When user attempts to create a round
+    │   │       └── Then it should revert
+    ├── And round end time is set 
+    │   ├── And round end != 0
+    │   ├── And round end < round start
+    │   │   └── When user attempts to create a round
+    │   │       └── Then it should revert
+    ├── And hook contract is set but hook function is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round end time is set and round end time is in the past
+    ├── And hook function is set but hook contract is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to create a round
-    │       └── Then it should revert
-    ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to create a round
-    │       └── Then it should revert
+    └── Given all the valid parameters are provided
+        └── When user attempts to create a round
+            └── Then it should not be active and should return the round id
     */
 
-    function testFuzzCreateRound_revertsGivenUserIsNotFundingPotAdmin(
-        address user_
-    ) public {
+    function testCreateRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
+        public
+    {
         vm.assume(user_ != address(0) && user_ != address(this));
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
@@ -137,13 +143,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
+
         _helper_callCreateRound(round);
         vm.stopPrank();
     }
 
-    function testFuzzCreateRound_revertsGivenRoundStartIsInThePast(
-        uint roundStart_
-    ) public {
+    function testCreateRound_revertsGivenRoundStartIsInThePast(uint roundStart_)
+        public
+    {
         vm.assume(roundStart_ < block.timestamp);
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -158,7 +165,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+    function testCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
         ILM_PC_FundingPot_v1.Round memory round =
@@ -175,7 +182,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+    function testCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
@@ -192,7 +199,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    function testCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -208,7 +215,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    function testCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -230,7 +237,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then it should not be active and should return the round id
     */
 
-    function testFuzzCreateRound() public {
+    function testCreateRound() public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
         _helper_callCreateRound(round);
@@ -248,9 +255,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(lastRound.globalAccumulativeCaps, round.globalAccumulativeCaps);
     }
 
-    /* Test editRound()
+    /* Test fuzzed editRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round
     │       └── Then it should revert
     ├── Given round does not exist
     │   └── When user attempts to edit the round
@@ -261,24 +268,28 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ├── Given round start time is in the past
     │   └── When user attempts to edit a round with the above parameter
     │       └── Then it should revert
-    ├── Given round end time is 0 and round cap is 0
-    │   └── When user attempts edit a round with the above parameters
-    │       └── Then it should revert
-    ├── Given round end time is set and round end time is in the past
+    ├── Given round end time == 0
+    │   ├── And round cap == 0
     │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
-    ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to edit a round with the above parameters
+    ├── Given round end time is set
+    │   ├── And round end is before round start
+    │   └── When user attempts to edit the round
     │       └── Then it should revert
-    ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to edit a round with the above parameters
+    ├── Given hook contract is set
+    │   ├── And hook function is empty
+    │   └── When user attempts to edit the round
     │       └── Then it should revert
+    └── Given hook function is set
+        ├── And hook contract is empty
+            └── When user attempts to edit the round
+                └── Then it should revert  
     */
 
     function testFuzzEditRound_revertsGivenUserIsNotFundingPotAdmin(
         address user_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
             address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
@@ -296,11 +307,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
-        testFuzzCreateRound();
+        testCreateRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+
         ILM_PC_FundingPot_v1.Round memory editedRound =
             _helper_createEditedRoundParams();
 
-        uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -314,7 +327,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
         public
     {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory roundDetails =
@@ -337,7 +350,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
         uint roundStart_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         vm.assume(roundStart_ < block.timestamp);
@@ -359,7 +372,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -381,7 +394,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -402,7 +415,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -423,7 +436,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -443,20 +456,21 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     /* Test editRound()
-    ├── Given a round has been created and is not active
-    │   └── When an admin provides valid parameters to edit the round
-    │       └── Then all the round details should be successfully updated
-    │           ├── roundStart should be updated to the new value
-    │           ├── roundEnd should be updated to the new value
-    │           ├── roundCap should be updated to the new value
-    │           ├── hookContract should be updated to the new value
-    │           ├── hookFunction should be updated to the new value
-    │           ├── closureMechanism should be updated to the new value
-    │           └── globalAccumulativeCaps should be updated to the new value
+    └── Given a round has been created
+    ├── And the round is not active
+    └── When an admin provides valid parameters to edit the round
+        └── Then all the round details should be successfully updated
+            ├── roundStart should be updated to the new value
+            ├── roundEnd should be updated to the new value
+            ├── roundCap should be updated to the new value
+            ├── hookContract should be updated to the new value
+            ├── hookFunction should be updated to the new value
+            ├── closureMechanism should be updated to the new value
+            └── globalAccumulativeCaps should be updated to the new value
     */
 
-    function testFuzzEditRound() public {
-        testFuzzCreateRound();
+    function testEditRound() public {
+        testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -506,7 +520,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // Helper Functions
 
     // @notice Creates a default funding round
-    // @dev make the parameters fuzzable @TODO Jeffrey
     function _generateFundingRoundParams(
         uint roundStart_,
         uint roundEnd_,

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -52,7 +52,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // SuT
     LM_PC_FundingPot_v1_Exposed fundingPot;
-    address public fundingPotAdmin = makeAddr("FundingPotAdmin");
 
     // -------------------------------------------------------------------------
     // Setup
@@ -70,8 +69,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Give test contract the DEPOSIT_ADMIN_ROLE.
         fundingPot.grantModuleRole(
-            fundingPot.FUNDING_POT_ADMIN_ROLE(), fundingPotAdmin
+            fundingPot.FUNDING_POT_ADMIN_ROLE(), address(this)
         );
+        _authorizer.setIsAuthorized(address(this), true);
+
+        // Set the block timestamp
+        vm.warp(block.timestamp + _orchestrator.MODULE_UPDATE_TIMELOCK());
     }
 
     // -------------------------------------------------------------------------
@@ -95,206 +98,261 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
     }
 
-    function test_fundingPotAdminRoleGranted() public {
-        bytes32 roleId = _orchestrator.authorizer().generateRoleId(
-            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
-        );
-        assertTrue(_orchestrator.authorizer().hasRole(roleId, fundingPotAdmin));
-    }
-
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
-    /* Test fuzzed createRound()
-        ├── Given a round start time is in the future
-        │   ├── And the round end time is either after the start or the round has a cap
-        │   │   └── When a new round is created with the given parameters
-        │   │       └── Then the stored round details should match the provided values
+    /* Test createRound()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round start time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is 0 and round cap is 0
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is set and round end time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook contract is set but hook function is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook function is set but hook contract is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
     */
-    function testFuzz_createRound(
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+
+    function testFuzzCreateRound_revertsGivenUserIsNotFundingPotAdmin(
+        address user_
     ) public {
-        vm.assume(roundStart > block.timestamp);
-        vm.assume(roundEnd > roundStart || roundCap > 0);
-        if (roundEnd > 0) {
-            vm.assume(roundEnd > roundStart);
-        }
-
-        uint64 roundId = fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+        vm.assume(user_ != address(0) && user_ != address(this));
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
         );
-
-        (uint storedStart, uint storedEnd, uint storedCap,,,,, bool isActive) =
-            fundingPot.rounds(roundId);
-
-        assertEq(storedStart, roundStart, "Round start mismatch");
-        assertEq(storedEnd, roundEnd, "Round end mismatch");
-        assertEq(storedCap, roundCap, "Round cap mismatch");
-        assertTrue(isActive, "Round should be active");
-    }
-
-    /* Test createRound() with invalid start time
-        ├── Given a start time that is in the past
-        │   └── When attempting to create a round with this past start time
-        │       └── Then it should revert with "Round start must be in the future"
-    */
-    function test_createRound_invalidStart() public {
-        uint pastTime = block.timestamp - 1;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
-                .selector
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
         );
-        fundingPot.createRound(
-            pastTime, block.timestamp + 10, 1000, address(0), "", false, false
-        );
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callCreateRound(round);
+        vm.stopPrank();
     }
 
-    /* Test createRound() with invalid end time
-        ├── Given a future start time
-        │   └── When attempting to create a round where end time is before start time and cap is zero
-        │       └── Then it should revert with "Round must have either end time or cap"
-    */
-    function test_createRound_invalidEnd() public {
-        uint futureTime = block.timestamp + 100;
-        vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
-                .selector
-        );
-        fundingPot.createRound(
-            futureTime, futureTime - 1, 0, address(0), "", false, false
-        );
-    }
-
-    /* Test fuzzed editRound()
-        ├── Given a round start time is in the future
-        │   ├── And the round end time is greater than zero and after the start time
-        │   │   └── When editing the round with new parameters
-        │   │       ├── Then the update should be successful
-        │   │       └── And the stored values should match the new parameters
-    */
-    function testFuzz_editRound(
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+    function testFuzzCreateRound_revertsGivenRoundStartIsInThePast(
+        uint roundStart_
     ) public {
-        vm.assume(roundStart > block.timestamp);
-        vm.assume(roundStart < type(uint).max - 100);
-        vm.assume(roundEnd > 0);
-        vm.assume(roundEnd > roundStart);
-        vm.assume(roundEnd <= type(uint).max - 100);
-        vm.assume(roundCap <= type(uint).max - 100);
-
-        uint64 roundId = fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+        vm.assume(roundStart_ < block.timestamp);
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.roundStart = roundStart_;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                    .selector
+            )
         );
-
-        uint newStart = roundStart + 100;
-        uint newEnd = roundEnd + 100;
-        uint newCap = roundCap + 100;
-
-        bool success = fundingPot.editRound(
-            roundId,
-            newStart,
-            newEnd,
-            newCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
-        );
-
-        assertTrue(success, "Round edit failed");
-
-        (uint storedStart, uint storedEnd, uint storedCap,,,,,) =
-            fundingPot.rounds(roundId);
-        assertEq(storedStart, newStart, "Updated round start mismatch");
-        assertEq(storedEnd, newEnd, "Updated round end mismatch");
-        assertEq(storedCap, newCap, "Updated round cap mismatch");
+        _callCreateRound(round);
     }
 
-    /* Test editRound() on nonexistent round
-        ├── Given a round does not exist
-        │   └── When attempting to edit the round
-        │       └── Then it should revert with "Round does not exist"
-    */
-    function test_editRound_nonexistent() public {
+    function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+        public
+    {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.roundEnd = 0;
+        round.roundCap = 0;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundDoesNotExist
-                .selector
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                    .selector
+            )
         );
-        fundingPot.editRound(
-            9999,
-            block.timestamp + 100,
-            block.timestamp + 200,
-            1000,
-            address(0),
-            "",
-            false,
-            false
-        );
+        _callCreateRound(round);
     }
 
-    /* Test editRound() after round has started
-        ├── Given a round has been created with a future start time
-        │   ├── And time has advanced beyond the start time
-        │   │   └── When attempting to edit the round
-        │   │       └── Then it should revert with "Round has already started"
-    */
-    function test_editRound_afterStart() public {
-        uint64 roundId = fundingPot.createRound(
-            block.timestamp + 10,
-            block.timestamp + 100,
-            1000,
-            address(0),
-            "",
-            false,
-            false
-        );
-
-        vm.warp(block.timestamp + 11);
-
+    function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+        uint roundEnd_
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < round.roundStart);
+        round.roundEnd = roundEnd_;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundAlreadyStarted
-                .selector
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundEndMustBeAfterStart
+                    .selector
+            )
         );
-        fundingPot.editRound(
-            roundId,
-            block.timestamp + 20,
-            block.timestamp + 200,
-            2000,
-            address(0),
-            "",
-            false,
-            false
+        _callCreateRound(round);
+    }
+
+    function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.hookContract = address(1);
+        round.hookFunction = bytes("");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract
+                    .selector
+            )
         );
+        _callCreateRound(round);
+    }
+
+    function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.hookContract = address(0);
+        round.hookFunction = bytes("test");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction
+                    .selector
+            )
+        );
+        _callCreateRound(round);
+    }
+
+    /* Test createRound()
+    ├── Given all the valid parameters are provided
+    │   └── When user attempts to create a round
+    │       └── Then it should not be active and should return the round id
+    */
+
+    function testFuzzCreateRound() public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callCreateRound(round);
+
+        uint64 lastRoundId = fundingPot.getRoundCount();
+        ILM_PC_FundingPot_v1.Round memory lastRound =
+            fundingPot.getRoundDetails(lastRoundId);
+
+        assertEq(lastRound.isActive, false);
+        assertEq(lastRound.roundStart, round.roundStart);
+        assertEq(lastRound.roundEnd, round.roundEnd);
+        assertEq(lastRound.roundCap, round.roundCap);
+        assertEq(lastRound.hookContract, round.hookContract);
+        assertEq(lastRound.hookFunction, round.hookFunction);
+        assertEq(lastRound.closureMechanism, round.closureMechanism);
+        assertEq(lastRound.globalAccumulativeCaps, round.globalAccumulativeCaps);
+    }
+
+    /* Test editRound()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
+    ├── Given round start time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is 0 and round cap is 0
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is set and round end time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook contract is set but hook function is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook function is set but hook contract is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    */
+
+    function testFuzzEditRound_revertsGivenUserIsNotFundingPotAdmin(
+        address user_
+    ) public {
+        testFuzzCreateRound();
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
+        );
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callEditRound(0, round);
+        vm.stopPrank();
+    }
+
+    function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
+        testFuzzCreateRound();
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundNotCreated
+                    .selector
+            )
+        );
+        _callEditRound(roundId + 1, round);
     }
 
     // -------------------------------------------------------------------------
     // Test: Internal Functions
+
+    // Helper Functions
+
+    // @notice Creates a default funding round
+    // @dev make the parameters fuzzable @TODO Jeffrey
+    function _createDefaultFundingRound()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
+            roundStart: block.timestamp + 1 days,
+            roundEnd: block.timestamp + 2 days,
+            roundCap: 1000,
+            hookContract: address(0),
+            hookFunction: bytes(""),
+            closureMechanism: false,
+            globalAccumulativeCaps: false,
+            isActive: false
+        });
+        return round;
+    }
+
+    function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
+        internal
+    {
+        fundingPot.createRound(
+            round.roundStart,
+            round.roundEnd,
+            round.roundCap,
+            round.hookContract,
+            round.hookFunction,
+            round.closureMechanism,
+            round.globalAccumulativeCaps
+        );
+    }
+
+    function _callEditRound(
+        uint64 roundId,
+        ILM_PC_FundingPot_v1.Round memory round
+    ) internal {
+        fundingPot.editRound(
+            roundId,
+            round.roundStart,
+            round.roundEnd,
+            round.roundCap,
+            round.hookContract,
+            round.hookFunction,
+            round.closureMechanism,
+            round.globalAccumulativeCaps
+        );
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -253,19 +253,19 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to edit the round
     │       └── Then it should revert
     ├── Given round start time is in the past
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameter
     │       └── Then it should revert
     ├── Given round end time is 0 and round cap is 0
-    │   └── When user attempts to create a round
+    │   └── When user attempts edit a round with the above parameters
     │       └── Then it should revert
     ├── Given round end time is set and round end time is in the past
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     */
 
@@ -282,14 +282,17 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callEditRound(0, round);
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+
+        _callEditRound(0, editedRound);
         vm.stopPrank();
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
         testFuzzCreateRound();
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
 
         uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
@@ -299,7 +302,196 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId + 1, round);
+        _callEditRound(roundId + 1, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
+        public
+    {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory roundDetails =
+            fundingPot.getRoundDetails(roundId);
+
+        vm.warp(roundDetails.roundStart + 1);
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                    .selector
+            )
+        );
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
+        uint roundStart_
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        vm.assume(roundStart_ < block.timestamp);
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.roundStart = roundStart_;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+        public
+    {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.roundEnd = 0;
+        editedRound.roundCap = 0;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+        uint roundEnd_
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < editedRound.roundStart);
+        editedRound.roundEnd = roundEnd_;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundEndMustBeAfterStart
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.hookContract = address(1);
+        editedRound.hookFunction = bytes("");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.hookContract = address(0);
+        editedRound.hookFunction = bytes("test");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    /* Test editRound()
+    ├── Given a round has been created and is not active
+    │   └── When an admin provides valid parameters to edit the round
+    │       └── Then all the round details should be successfully updated
+    │           ├── roundStart should be updated to the new value
+    │           ├── roundEnd should be updated to the new value
+    │           ├── roundCap should be updated to the new value
+    │           ├── hookContract should be updated to the new value
+    │           ├── hookFunction should be updated to the new value
+    │           ├── closureMechanism should be updated to the new value
+    │           └── globalAccumulativeCaps should be updated to the new value
+    */
+
+    function testFuzzEditRound() public {
+        testFuzzCreateRound();
+        uint64 lastRoundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+
+        _callEditRound(lastRoundId, editedRound);
+
+        ILM_PC_FundingPot_v1.Round memory updatedRound =
+            fundingPot.getRoundDetails(lastRoundId);
+
+        assertEq(
+            updatedRound.roundStart,
+            editedRound.roundStart,
+            "roundStart not updated"
+        );
+        assertEq(
+            updatedRound.roundEnd, editedRound.roundEnd, "roundEnd not updated"
+        );
+        assertEq(
+            updatedRound.roundCap, editedRound.roundCap, "roundCap not updated"
+        );
+        assertEq(
+            updatedRound.hookContract,
+            editedRound.hookContract,
+            "hookContract not updated"
+        );
+        assertEq(
+            keccak256(updatedRound.hookFunction),
+            keccak256(editedRound.hookFunction),
+            "hookFunction not updated"
+        );
+        assertEq(
+            updatedRound.closureMechanism,
+            editedRound.closureMechanism,
+            "closureMechanism not updated"
+        );
+        assertEq(
+            updatedRound.globalAccumulativeCaps,
+            editedRound.globalAccumulativeCaps,
+            "globalAccumulativeCaps not updated"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -309,23 +501,45 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // @notice Creates a default funding round
     // @dev make the parameters fuzzable @TODO Jeffrey
-    function _createDefaultFundingRound()
-        internal
-        returns (ILM_PC_FundingPot_v1.Round memory)
-    {
+    function _generateFundingRoundParams(
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
+    ) internal returns (ILM_PC_FundingPot_v1.Round memory) {
         ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
-            roundStart: block.timestamp + 1 days,
-            roundEnd: block.timestamp + 2 days,
-            roundCap: 1000,
-            hookContract: address(0),
-            hookFunction: bytes(""),
-            closureMechanism: false,
-            globalAccumulativeCaps: false,
+            roundStart: roundStart_,
+            roundEnd: roundEnd_,
+            roundCap: roundCap_,
+            hookContract: hookContract_,
+            hookFunction: hookFunction_,
+            closureMechanism: closureMechanism_,
+            globalAccumulativeCaps: globalAccumulativeCaps_,
             isActive: false
         });
         return round;
     }
 
+    // @notice Creates a default funding round
+    function _createDefaultFundingRound()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        return _generateFundingRoundParams(
+            block.timestamp + 1 days,
+            block.timestamp + 2 days,
+            1000,
+            address(0),
+            bytes(""),
+            false,
+            false
+        );
+    }
+
+    // @notice calls the create round function
     function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
         internal
     {
@@ -340,6 +554,23 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
+    // @notice Creates a predefined funding round with edited parameters for testing
+    function _createEditedRoundParams()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        return _generateFundingRoundParams(
+            block.timestamp + 150,
+            block.timestamp + 250,
+            20,
+            address(0x1),
+            hex"abcd",
+            true,
+            true
+        );
+    }
+
+    // @notice calls the create round function
     function _callEditRound(
         uint64 roundId,
         ILM_PC_FundingPot_v1.Round memory round

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -105,6 +105,196 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
+    /* Test fuzzed createRound()
+        ├── Given a round start time is in the future
+        │   ├── And the round end time is either after the start or the round has a cap
+        │   │   └── When a new round is created with the given parameters
+        │   │       └── Then the stored round details should match the provided values
+    */
+    function testFuzz_createRound(
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    ) public {
+        vm.assume(roundStart > block.timestamp);
+        vm.assume(roundEnd > roundStart || roundCap > 0);
+        if (roundEnd > 0) {
+            vm.assume(roundEnd > roundStart);
+        }
+
+        uint64 roundId = fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        (uint storedStart, uint storedEnd, uint storedCap,,,,, bool isActive) =
+            fundingPot.rounds(roundId);
+
+        assertEq(storedStart, roundStart, "Round start mismatch");
+        assertEq(storedEnd, roundEnd, "Round end mismatch");
+        assertEq(storedCap, roundCap, "Round cap mismatch");
+        assertTrue(isActive, "Round should be active");
+    }
+
+    /* Test createRound() with invalid start time
+        ├── Given a start time that is in the past
+        │   └── When attempting to create a round with this past start time
+        │       └── Then it should revert with "Round start must be in the future"
+    */
+    function test_createRound_invalidStart() public {
+        uint pastTime = block.timestamp - 1;
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                .selector
+        );
+        fundingPot.createRound(
+            pastTime, block.timestamp + 10, 1000, address(0), "", false, false
+        );
+    }
+
+    /* Test createRound() with invalid end time
+        ├── Given a future start time
+        │   └── When attempting to create a round where end time is before start time and cap is zero
+        │       └── Then it should revert with "Round must have either end time or cap"
+    */
+    function test_createRound_invalidEnd() public {
+        uint futureTime = block.timestamp + 100;
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                .selector
+        );
+        fundingPot.createRound(
+            futureTime, futureTime - 1, 0, address(0), "", false, false
+        );
+    }
+
+    /* Test fuzzed editRound()
+        ├── Given a round start time is in the future
+        │   ├── And the round end time is greater than zero and after the start time
+        │   │   └── When editing the round with new parameters
+        │   │       ├── Then the update should be successful
+        │   │       └── And the stored values should match the new parameters
+    */
+    function testFuzz_editRound(
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    ) public {
+        vm.assume(roundStart > block.timestamp);
+        vm.assume(roundStart < type(uint).max - 100);
+        vm.assume(roundEnd > 0);
+        vm.assume(roundEnd > roundStart);
+        vm.assume(roundEnd <= type(uint).max - 100);
+        vm.assume(roundCap <= type(uint).max - 100);
+
+        uint64 roundId = fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        uint newStart = roundStart + 100;
+        uint newEnd = roundEnd + 100;
+        uint newCap = roundCap + 100;
+
+        bool success = fundingPot.editRound(
+            roundId,
+            newStart,
+            newEnd,
+            newCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        assertTrue(success, "Round edit failed");
+
+        (uint storedStart, uint storedEnd, uint storedCap,,,,,) =
+            fundingPot.rounds(roundId);
+        assertEq(storedStart, newStart, "Updated round start mismatch");
+        assertEq(storedEnd, newEnd, "Updated round end mismatch");
+        assertEq(storedCap, newCap, "Updated round cap mismatch");
+    }
+
+    /* Test editRound() on nonexistent round
+        ├── Given a round does not exist
+        │   └── When attempting to edit the round
+        │       └── Then it should revert with "Round does not exist"
+    */
+    function test_editRound_nonexistent() public {
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundDoesNotExist
+                .selector
+        );
+        fundingPot.editRound(
+            9999,
+            block.timestamp + 100,
+            block.timestamp + 200,
+            1000,
+            address(0),
+            "",
+            false,
+            false
+        );
+    }
+
+    /* Test editRound() after round has started
+        ├── Given a round has been created with a future start time
+        │   ├── And time has advanced beyond the start time
+        │   │   └── When attempting to edit the round
+        │   │       └── Then it should revert with "Round has already started"
+    */
+    function test_editRound_afterStart() public {
+        uint64 roundId = fundingPot.createRound(
+            block.timestamp + 10,
+            block.timestamp + 100,
+            1000,
+            address(0),
+            "",
+            false,
+            false
+        );
+
+        vm.warp(block.timestamp + 11);
+
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                .selector
+        );
+        fundingPot.editRound(
+            roundId,
+            block.timestamp + 20,
+            block.timestamp + 200,
+            2000,
+            address(0),
+            "",
+            false,
+            false
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test: Internal Functions
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -135,8 +135,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callCreateRound(round);
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
+        _helper_callCreateRound(round);
         vm.stopPrank();
     }
 
@@ -144,7 +145,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundStart_
     ) public {
         vm.assume(roundStart_ < block.timestamp);
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.roundStart = roundStart_;
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -153,13 +155,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.roundEnd = 0;
         round.roundCap = 0;
         vm.expectRevert(
@@ -169,13 +172,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         vm.assume(roundEnd_ != 0 && roundEnd_ < round.roundStart);
         round.roundEnd = roundEnd_;
         vm.expectRevert(
@@ -185,12 +189,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.hookContract = address(1);
         round.hookFunction = bytes("");
         vm.expectRevert(
@@ -200,12 +205,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.hookContract = address(0);
         round.hookFunction = bytes("test");
         vm.expectRevert(
@@ -215,7 +221,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     /* Test createRound()
@@ -225,14 +231,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testFuzzCreateRound() public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callCreateRound(round);
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
+        _helper_callCreateRound(round);
 
         uint64 lastRoundId = fundingPot.getRoundCount();
         ILM_PC_FundingPot_v1.Round memory lastRound =
             fundingPot.getRoundDetails(lastRoundId);
 
-        assertEq(lastRound.isActive, false);
         assertEq(lastRound.roundStart, round.roundStart);
         assertEq(lastRound.roundEnd, round.roundEnd);
         assertEq(lastRound.roundCap, round.roundCap);
@@ -283,16 +289,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
-        _callEditRound(0, editedRound);
+        _helper_callEditRound(0, editedRound);
         vm.stopPrank();
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
         testFuzzCreateRound();
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
         uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
@@ -302,7 +308,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId + 1, editedRound);
+        _helper_callEditRound(roundId + 1, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
@@ -317,7 +323,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundDetails.roundStart + 1);
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -325,7 +331,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
@@ -336,7 +342,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.assume(roundStart_ < block.timestamp);
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.roundStart = roundStart_;
 
         vm.expectRevert(
@@ -347,7 +353,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
@@ -357,7 +363,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.roundEnd = 0;
         editedRound.roundCap = 0;
 
@@ -369,7 +375,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
@@ -379,7 +385,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         vm.assume(roundEnd_ != 0 && roundEnd_ < editedRound.roundStart);
         editedRound.roundEnd = roundEnd_;
 
@@ -391,7 +397,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
@@ -400,7 +406,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.hookContract = address(1);
         editedRound.hookFunction = bytes("");
 
@@ -412,7 +418,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
@@ -421,7 +427,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.hookContract = address(0);
         editedRound.hookFunction = bytes("test");
 
@@ -433,7 +439,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     /* Test editRound()
@@ -454,9 +460,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
-        _callEditRound(lastRoundId, editedRound);
+        _helper_callEditRound(lastRoundId, editedRound);
 
         ILM_PC_FundingPot_v1.Round memory updatedRound =
             fundingPot.getRoundDetails(lastRoundId);
@@ -517,17 +523,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: hookContract_,
             hookFunction: hookFunction_,
             closureMechanism: closureMechanism_,
-            globalAccumulativeCaps: globalAccumulativeCaps_,
-            isActive: false
+            globalAccumulativeCaps: globalAccumulativeCaps_
         });
         return round;
     }
 
     // @notice Creates a default funding round
-    function _createDefaultFundingRound()
+    function _helper_createDefaultFundingRound()
         internal
         returns (ILM_PC_FundingPot_v1.Round memory)
     {
+        //@todo need to randomize the input using vm.bound or vm.assume, do the same for the edited round
+        //@33 do you have any input here?
         return _generateFundingRoundParams(
             block.timestamp + 1 days,
             block.timestamp + 2 days,
@@ -540,7 +547,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice calls the create round function
-    function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
+    function _helper_callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
         internal
     {
         fundingPot.createRound(
@@ -555,7 +562,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice Creates a predefined funding round with edited parameters for testing
-    function _createEditedRoundParams()
+    function _helper_createEditedRoundParams()
         internal
         returns (ILM_PC_FundingPot_v1.Round memory)
     {
@@ -571,7 +578,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice calls the create round function
-    function _callEditRound(
+    function _helper_callEditRound(
         uint64 roundId,
         ILM_PC_FundingPot_v1.Round memory round
     ) internal {

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity 0.8.23;
 
 // Internal
 import {LM_PC_FundingPot_v1} from


### PR DESCRIPTION
## Pull Request Note

### Overview
This pull request is for the review of the `Funding_Pot_v1` contracts after cloning from the template and adding Funding Pot Admin Authorization implementation and `createRound()` and `editRound()`

### Key Changes
- **Funding Pot Admin:** Added logic to allow only the `FUNDING_POT_ADMIN_ROLE` to call `createRound()` and `editRound()`
- **Input Validation:** Added various custom errors to handle incorrect input validation and revert in case invalid input is passed
- **Unit Tests:**
  - Added unit fuzz tests for `createRound()` and `editRound()` following the gherkin style method
- **Code Cleanup:** Removed unnecessary state variables and outdated templates to streamline the codebase.

### Focus Areas
- Provide feedback on input validation checks, any edge case leading to bug/security concern
-any changes wrt Inverter coding standard