### PR TITLE
House Protocol Looping Feature

### DIFF
--- a/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
@@ -113,9 +113,6 @@ contract LM_PC_Lending_Facility_v1 is
     /// @notice Maximum borrowable quota percentage (100%)
     uint internal constant _MAX_BORROWABLE_QUOTA = 10_000; // 100% in basis points
 
-    /// @notice Maximum leverage buyAndBorrow loops
-    uint public constant _MAX_LEVERAGE = 50;
-
     //--------------------------------------------------------------------------
     // State
 
@@ -128,6 +125,9 @@ contract LM_PC_Lending_Facility_v1 is
 
     /// @notice Individual borrow limit per user
     uint public individualBorrowLimit;
+
+    /// @notice Maximum leverage allowed for buyAndBorrow operations
+    uint public maxLeverage;
 
     /// @notice Currently borrowed amount across all users
     uint public currentlyBorrowedAmount;
@@ -184,9 +184,10 @@ contract LM_PC_Lending_Facility_v1 is
             address dbcFmAddress,
             address dynamicFeeCalculator,
             uint borrowableQuota_,
-            uint individualBorrowLimit_
+            uint individualBorrowLimit_,
+            uint maxLeverage_
         ) = abi.decode(
-            configData_, (address, address, address, address, uint, uint)
+            configData_, (address, address, address, address, uint, uint, uint)
         );
 
         // Set init state
@@ -196,6 +197,7 @@ contract LM_PC_Lending_Facility_v1 is
         _dynamicFeeCalculator = dynamicFeeCalculator;
         borrowableQuota = borrowableQuota_;
         individualBorrowLimit = individualBorrowLimit_;
+        maxLeverage = maxLeverage_;
     }
 
     // =========================================================================
@@ -327,8 +329,7 @@ contract LM_PC_Lending_Facility_v1 is
     function buyAndBorrow(uint leverage_) external virtual {
         address user = _msgSender();
 
-        // Require leverage to be at least 1 (minimum 1 loop)
-        if (leverage_ < 1 || leverage_ > _MAX_LEVERAGE) {
+        if (leverage_ < 1 || leverage_ > maxLeverage) {
             revert
                 ILM_PC_Lending_Facility_v1
                 .Module__LM_PC_Lending_Facility_InvalidLeverage();
@@ -466,6 +467,21 @@ contract LM_PC_Lending_Facility_v1 is
         }
         _dynamicFeeCalculator = newFeeCalculator_;
         emit DynamicFeeCalculatorUpdated(newFeeCalculator_);
+    }
+
+    /// @notice Set the maximum leverage allowed for buyAndBorrow operations
+    /// @param newMaxLeverage_ The new maximum leverage (must be >= 1)
+    function setMaxLeverage(uint newMaxLeverage_)
+        external
+        onlyLendingFacilityManager
+    {
+        if (newMaxLeverage_ < 1 || newMaxLeverage_ > type(uint8).max) {
+            revert
+                ILM_PC_Lending_Facility_v1
+                .Module__LM_PC_Lending_Facility_InvalidLeverage();
+        }
+        maxLeverage = newMaxLeverage_;
+        emit MaxLeverageUpdated(newMaxLeverage_);
     }
 
     // =========================================================================

--- a/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
@@ -200,7 +200,7 @@ contract LM_PC_Lending_Facility_v1 is
 
     /// @inheritdoc ILM_PC_Lending_Facility_v1
     function borrow(uint requestedLoanAmount_)
-        external
+        public
         virtual
         onlyValidBorrowAmount(requestedLoanAmount_)
     {
@@ -229,6 +229,8 @@ contract LM_PC_Lending_Facility_v1 is
                 ILM_PC_Lending_Facility_v1
                 .Module__LM_PC_Lending_Facility_IndividualBorrowLimitExceeded();
         }
+
+        _issuanceToken.approve(address(this), requiredIssuanceTokens);
 
         // Lock the required issuance tokens automatically
         _issuanceToken.safeTransferFrom(
@@ -316,6 +318,108 @@ contract LM_PC_Lending_Facility_v1 is
 
         // Emit event
         emit IssuanceTokensUnlocked(user, amount_);
+    }
+
+    /// @inheritdoc ILM_PC_Lending_Facility_v1
+    function buyAndBorrow(uint leverage_) external virtual {
+        address user = _msgSender();
+
+        // Require leverage to be at least 1 (minimum 1 loop)
+        if (leverage_ < 1) {
+            revert
+                ILM_PC_Lending_Facility_v1
+                .Module__LM_PC_Lending_Facility_InvalidLeverage();
+        }
+
+        // Track total issuance tokens received and total borrowed
+        uint totalIssuanceTokensReceived = 0;
+        uint totalBorrowed = 0;
+        uint totalCollateralUsed = 0;
+
+        // Loop through leverage iterations
+        for (uint8 i = 0; i < leverage_; i++) {
+            // Get user's collateral balance
+            uint userCollateralBalance = _collateralToken.balanceOf(user);
+            if (userCollateralBalance == 0) {
+                revert
+                    ILM_PC_Lending_Facility_v1
+                    .Module__LM_PC_Lending_Facility_NoCollateralAvailable();
+            }
+
+            if (userCollateralBalance < 1) break;
+
+            // Calculate how much collateral to use for the initial purchase
+            uint collateralForPurchase = userCollateralBalance;
+
+            // Calculate minimum amount of issuance tokens expected from the purchase
+            uint minIssuanceTokensOut = IBondingCurveBase_v1(_dbcFmAddress)
+                .calculatePurchaseReturn(collateralForPurchase);
+
+            // Require minimum issuance tokens to be greater than 0
+            if (minIssuanceTokensOut == 0) {
+                revert
+                    ILM_PC_Lending_Facility_v1
+                    .Module__LM_PC_Lending_Facility_InsufficientIssuanceTokensReceived(
+                );
+            }
+
+            // Transfer collateral from user to this contract for this iteration
+            _collateralToken.safeTransferFrom(
+                user, address(this), collateralForPurchase
+            );
+
+            _collateralToken.approve(_dbcFmAddress, collateralForPurchase);
+
+            // Buy issuance tokens from the funding manager
+            IBondingCurveBase_v1(_dbcFmAddress).buyFor(
+                user, // receiver (user)
+                collateralForPurchase, // deposit amount
+                minIssuanceTokensOut // minimum amount out
+            );
+
+            // Get the actual amount of issuance tokens received in this iteration
+            uint actualIssuanceTokensReceived =
+                _issuanceToken.balanceOf(user) - totalIssuanceTokensReceived;
+            if (actualIssuanceTokensReceived == 0) {
+                revert
+                    ILM_PC_Lending_Facility_v1
+                    .Module__LM_PC_Lending_Facility_NoIssuanceTokensInIteration();
+            }
+
+            // Add to total issuance tokens received
+            totalIssuanceTokensReceived += actualIssuanceTokensReceived;
+
+            // Track collateral used in this iteration
+            totalCollateralUsed += collateralForPurchase;
+
+            // Now calculate borrowing power based on balance of issuance
+            uint borrowingPower =
+                _calculateCollateralAmount(actualIssuanceTokensReceived);
+
+            // Calculate how much can be borrowed in this iteration
+            // Each iteration can borrow up to the value of the issuance tokens received
+            uint borrowAmountThisIteration = borrowingPower;
+
+            // If we can't borrow anything more, break the loop
+            if (borrowAmountThisIteration <= 0) {
+                break;
+            }
+
+            // Call the borrow function with the calculated amount
+            borrow(borrowAmountThisIteration);
+
+            // Update our tracking
+            totalBorrowed += borrowAmountThisIteration;
+        }
+
+        // Emit event for the completed buyAndBorrow operation
+        emit ILM_PC_Lending_Facility_v1.BuyAndBorrowCompleted(
+            user,
+            leverage_,
+            totalIssuanceTokensReceived,
+            totalBorrowed,
+            totalCollateralUsed
+        );
     }
 
     // =========================================================================

--- a/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
@@ -113,6 +113,9 @@ contract LM_PC_Lending_Facility_v1 is
     /// @notice Maximum borrowable quota percentage (100%)
     uint internal constant _MAX_BORROWABLE_QUOTA = 10_000; // 100% in basis points
 
+    /// @notice Maximum leverage buyAndBorrow loops
+    uint public constant _MAX_LEVERAGE = 50;
+
     //--------------------------------------------------------------------------
     // State
 
@@ -325,7 +328,7 @@ contract LM_PC_Lending_Facility_v1 is
         address user = _msgSender();
 
         // Require leverage to be at least 1 (minimum 1 loop)
-        if (leverage_ < 1) {
+        if (leverage_ < 1 || leverage_ > _MAX_LEVERAGE) {
             revert
                 ILM_PC_Lending_Facility_v1
                 .Module__LM_PC_Lending_Facility_InvalidLeverage();

--- a/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/LM_PC_Lending_Facility_v1.sol
@@ -336,9 +336,9 @@ contract LM_PC_Lending_Facility_v1 is
         }
 
         // Track total issuance tokens received and total borrowed
-        uint totalIssuanceTokensReceived = 0;
-        uint totalBorrowed = 0;
-        uint totalCollateralUsed = 0;
+        uint totalIssuanceTokensReceived;
+        uint totalBorrowed;
+        uint totalCollateralUsed;
 
         // Loop through leverage iterations
         for (uint8 i = 0; i < leverage_; i++) {
@@ -352,12 +352,9 @@ contract LM_PC_Lending_Facility_v1 is
 
             if (userCollateralBalance < 1) break;
 
-            // Calculate how much collateral to use for the initial purchase
-            uint collateralForPurchase = userCollateralBalance;
-
             // Calculate minimum amount of issuance tokens expected from the purchase
             uint minIssuanceTokensOut = IBondingCurveBase_v1(_dbcFmAddress)
-                .calculatePurchaseReturn(collateralForPurchase);
+                .calculatePurchaseReturn(userCollateralBalance);
 
             // Require minimum issuance tokens to be greater than 0
             if (minIssuanceTokensOut == 0) {
@@ -369,15 +366,15 @@ contract LM_PC_Lending_Facility_v1 is
 
             // Transfer collateral from user to this contract for this iteration
             _collateralToken.safeTransferFrom(
-                user, address(this), collateralForPurchase
+                user, address(this), userCollateralBalance
             );
 
-            _collateralToken.approve(_dbcFmAddress, collateralForPurchase);
+            _collateralToken.approve(_dbcFmAddress, userCollateralBalance);
 
             // Buy issuance tokens from the funding manager
             IBondingCurveBase_v1(_dbcFmAddress).buyFor(
                 user, // receiver (user)
-                collateralForPurchase, // deposit amount
+                userCollateralBalance, // deposit amount
                 minIssuanceTokensOut // minimum amount out
             );
 
@@ -394,30 +391,26 @@ contract LM_PC_Lending_Facility_v1 is
             totalIssuanceTokensReceived += actualIssuanceTokensReceived;
 
             // Track collateral used in this iteration
-            totalCollateralUsed += collateralForPurchase;
+            totalCollateralUsed += userCollateralBalance;
 
             // Now calculate borrowing power based on balance of issuance
             uint borrowingPower =
                 _calculateCollateralAmount(actualIssuanceTokensReceived);
 
-            // Calculate how much can be borrowed in this iteration
-            // Each iteration can borrow up to the value of the issuance tokens received
-            uint borrowAmountThisIteration = borrowingPower;
-
             // If we can't borrow anything more, break the loop
-            if (borrowAmountThisIteration <= 0) {
+            if (borrowingPower <= 0) {
                 break;
             }
 
             // Call the borrow function with the calculated amount
-            borrow(borrowAmountThisIteration);
+            borrow(borrowingPower);
 
             // Update our tracking
-            totalBorrowed += borrowAmountThisIteration;
+            totalBorrowed += borrowingPower;
         }
 
         // Emit event for the completed buyAndBorrow operation
-        emit ILM_PC_Lending_Facility_v1.BuyAndBorrowCompleted(
+        emit BuyAndBorrowCompleted(
             user,
             leverage_,
             totalIssuanceTokensReceived,

--- a/src/modules/logicModule/interfaces/ILM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_Lending_Facility_v1.sol
@@ -70,6 +70,20 @@ interface ILM_PC_Lending_Facility_v1 is IERC20PaymentClientBase_v2 {
     /// @param newCalculator The new fee calculator address
     event DynamicFeeCalculatorUpdated(address newCalculator);
 
+    /// @notice Emitted when a user completes a buyAndBorrow operation
+    /// @param user The address of the user who performed the operation
+    /// @param leverage The leverage used for the operation
+    /// @param totalIssuanceTokensReceived Total issuance tokens received from all iterations
+    /// @param totalBorrowed Total amount borrowed across all iterations
+    /// @param collateralUsed Total collateral used for the operation
+    event BuyAndBorrowCompleted(
+        address indexed user,
+        uint leverage,
+        uint totalIssuanceTokensReceived,
+        uint totalBorrowed,
+        uint collateralUsed
+    );
+
     // =========================================================================
     // Errors
 
@@ -105,6 +119,18 @@ interface ILM_PC_Lending_Facility_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Invalid fee calculator address
     error Module__LM_PC_Lending_Facility_InvalidFeeCalculatorAddress();
+
+    /// @notice Leverage must be at least 1
+    error Module__LM_PC_Lending_Facility_InvalidLeverage();
+
+    /// @notice No collateral tokens available for the user
+    error Module__LM_PC_Lending_Facility_NoCollateralAvailable();
+
+    /// @notice Insufficient issuance tokens would be received from purchase
+    error Module__LM_PC_Lending_Facility_InsufficientIssuanceTokensReceived();
+
+    /// @notice No issuance tokens received in iteration
+    error Module__LM_PC_Lending_Facility_NoIssuanceTokensInIteration();
 
     // =========================================================================
     // Public - Getters
@@ -159,6 +185,10 @@ interface ILM_PC_Lending_Facility_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Unlock issuance tokens (only if no outstanding loan)
     /// @param amount_ The amount of issuance tokens to unlock
     function unlockIssuanceTokens(uint amount_) external;
+
+    /// @notice Buy issuance tokens and borrow against them in a single transaction
+    /// @param leverage_ The leverage multiplier for the borrowing (must be >= 1)
+    function buyAndBorrow(uint leverage_) external;
 
     // =========================================================================
     // Public - Configuration (Lending Facility Manager only)

--- a/src/modules/logicModule/interfaces/ILM_PC_Lending_Facility_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_Lending_Facility_v1.sol
@@ -84,6 +84,10 @@ interface ILM_PC_Lending_Facility_v1 is IERC20PaymentClientBase_v2 {
         uint collateralUsed
     );
 
+    /// @notice Emitted when the maximum leverage is updated
+    /// @param newMaxLeverage The new maximum leverage
+    event MaxLeverageUpdated(uint newMaxLeverage);
+
     // =========================================================================
     // Errors
 

--- a/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
@@ -79,6 +79,7 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
     uint constant INDIVIDUAL_BORROW_LIMIT = 500 ether;
     uint constant LOCKED_ISSUANCE_TOKENS = 1000 ether;
     uint constant MAX_FEE_PERCENTAGE = 1e18;
+    uint constant MAX_LEVERAGE = 50;
 
     // Structs for organizing test data
     struct CurveTestData {
@@ -273,7 +274,8 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
                 address(fmBcDiscrete),
                 address(dynamicFeeCalculator),
                 BORROWABLE_QUOTA,
-                INDIVIDUAL_BORROW_LIMIT
+                INDIVIDUAL_BORROW_LIMIT,
+                MAX_LEVERAGE
             )
         );
 
@@ -1011,9 +1013,8 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         orchestratorToken.mint(user, 100 ether);
         fmBcDiscrete.openBuy();
 
-        leverage_ = bound(
-            leverage_, lendingFacility._MAX_LEVERAGE() + 1, type(uint8).max
-        );
+        leverage_ =
+            bound(leverage_, lendingFacility.maxLeverage() + 1, type(uint8).max);
         uint leverage = leverage_;
 
         vm.startPrank(user);
@@ -1039,7 +1040,7 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         // Given: a user wants to use buyAndBorrow
         address user = makeAddr("user");
 
-        leverage_ = bound(leverage_, 1, lendingFacility._MAX_LEVERAGE());
+        leverage_ = bound(leverage_, 1, lendingFacility.maxLeverage());
         uint leverage = leverage_;
 
         vm.prank(user);
@@ -1254,6 +1255,35 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
                 .selector
         );
         lendingFacility.setDynamicFeeCalculator(invalidFeeCalculator);
+    }
+
+    /* Test external setMaxLeverage function
+        ├── Given caller has LENDING_FACILITY_MANAGER_ROLE
+        │   └── When setting new maximum leverage
+        │       ├── Then the maximum leverage should be updated
+        └── Given invalid maximum leverage
+            └── When trying to set maximum leverage
+                └── Then it should revert with InvalidLeverage
+    */
+
+    function testFuzzPublicSetMaxLeverage_succeedsGivenValidLeverage(
+        uint newMaxLeverage_
+    ) public {
+        newMaxLeverage_ = bound(newMaxLeverage_, 1, type(uint8).max);
+        uint newMaxLeverage = newMaxLeverage_;
+        lendingFacility.setMaxLeverage(newMaxLeverage);
+
+        assertEq(lendingFacility.maxLeverage(), newMaxLeverage);
+    }
+
+    function testPublicSetMaxLeverage_failsGivenInvalidLeverage() public {
+        uint invalidMaxLeverage = 0;
+        vm.expectRevert(
+            ILM_PC_Lending_Facility_v1
+                .Module__LM_PC_Lending_Facility_InvalidLeverage
+                .selector
+        );
+        lendingFacility.setMaxLeverage(invalidMaxLeverage);
     }
 
     // =========================================================================

--- a/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
@@ -997,6 +997,71 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
     // =========================================================================
     // Test: Buy and Borrow
 
+    /* Test: Function buyAndBorrow()
+        ├── Given a user wants to use buyAndBorrow
+        └── And the user provides leverage exceeding maximum allowed limit
+            └── When the user executes buyAndBorrow
+                └── Then the transaction should revert with InvalidLeverage error
+    */
+    function testFuzzPublicBuyAndBorrow_revertsGivenInvalidLeverage(
+        uint leverage_
+    ) public {
+        // Given: a user wants to use buyAndBorrow
+        address user = makeAddr("user");
+        orchestratorToken.mint(user, 100 ether);
+        fmBcDiscrete.openBuy();
+
+        leverage_ = bound(
+            leverage_, lendingFacility._MAX_LEVERAGE() + 1, type(uint8).max
+        );
+        uint leverage = leverage_;
+
+        vm.startPrank(user);
+        vm.expectRevert(
+            ILM_PC_Lending_Facility_v1
+                .Module__LM_PC_Lending_Facility_InvalidLeverage
+                .selector
+        );
+        lendingFacility.buyAndBorrow(leverage);
+        vm.stopPrank();
+    }
+
+    /* Test: Function buyAndBorrow()
+        ├── Given a user wants to use buyAndBorrow
+        │   └── And the user has no collateral tokens
+        │       └── When the user executes buyAndBorrow
+        │           └── Then the transaction should revert with NoCollateralAvailable error
+    */
+
+    function testFuzzPublicBuyAndBorrow_revertsGivenNoCollateralAvailable(
+        uint leverage_
+    ) public {
+        // Given: a user wants to use buyAndBorrow
+        address user = makeAddr("user");
+
+        leverage_ = bound(leverage_, 1, lendingFacility._MAX_LEVERAGE());
+        uint leverage = leverage_;
+
+        vm.prank(user);
+        vm.expectRevert(
+            ILM_PC_Lending_Facility_v1
+                .Module__LM_PC_Lending_Facility_NoCollateralAvailable
+                .selector
+        );
+        lendingFacility.buyAndBorrow(leverage);
+    }
+
+    /* Test: Function buyAndBorrow()
+        ├── Given a user wants to use buyAndBorrow
+        │   └── And the user has sufficient collateral tokens
+        │   └── And the bonding curve is open for buying
+        │   └── And the user provides valid leverage within limits
+        │   └── And the user has approved sufficient token allowances
+        │       └── When the user executes buyAndBorrow
+        │           ├── Then the user should receive issuance tokens from the buy operation
+        │           ├── And the user's collateral balance should decrease (due to fees and purchases)
+        │           └── And the user should have an outstanding loan
+    */
     function testPublicBuyAndBorrow_succeedsGivenValidLeverage() public {
         // Given: a user has issuance tokens
         address user = makeAddr("user");

--- a/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
@@ -1063,44 +1063,31 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         │           ├── And the user's collateral balance should decrease (due to fees and purchases)
         │           └── And the user should have an outstanding loan
     */
-    function testPublicBuyAndBorrow_succeedsGivenValidLeverage() public {
+    function testFuzzPublicBuyAndBorrow_succeedsGivenValidLeverage(
+        uint leverage_,
+        uint collateralAmount_
+    ) public {
         // Given: a user has issuance tokens
         address user = makeAddr("user");
-        orchestratorToken.mint(user, 100 ether);
+        leverage_ = bound(leverage_, 1, lendingFacility.maxLeverage());
+        uint leverage = leverage_;
 
+        collateralAmount_ = bound(collateralAmount_, 1 ether, 100 ether);
+
+        orchestratorToken.mint(user, collateralAmount_); // @note : Keeping this fixed for now, since fuzzing this results in various reverts.
         fmBcDiscrete.openBuy();
 
-        // Record initial state
-        uint userCollateralBalanceBefore = orchestratorToken.balanceOf(user);
-        uint userIssuanceBalanceBefore = issuanceToken.balanceOf(user);
         uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
 
         vm.startPrank(user);
         orchestratorToken.approve(address(fmBcDiscrete), type(uint).max);
         orchestratorToken.approve(address(lendingFacility), type(uint).max);
-        issuanceToken.approve(address(fmBcDiscrete), type(uint).max);
         issuanceToken.approve(address(lendingFacility), type(uint).max);
 
-        lendingFacility.buyAndBorrow(25);
+        lendingFacility.buyAndBorrow(leverage);
         vm.stopPrank();
 
         // Then: verify state changes
-        // User should have received issuance tokens from the buy operation
-        uint userIssuanceBalanceAfter = issuanceToken.balanceOf(user);
-        assertGt(
-            userIssuanceBalanceAfter,
-            userIssuanceBalanceBefore,
-            "User should receive issuance tokens from buy operation"
-        );
-
-        // User should have some collateral remaining (less than initial amount due to fees and purchases)
-        uint userCollateralBalanceAfter = orchestratorToken.balanceOf(user);
-        assertLt(
-            userCollateralBalanceAfter,
-            userCollateralBalanceBefore,
-            "User should have spent some collateral on purchases"
-        );
-
         // User should have an outstanding loan
         uint outstandingLoanAfter = lendingFacility.getOutstandingLoan(user);
         assertGt(
@@ -1108,6 +1095,81 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
             outstandingLoanBefore,
             "User should have an outstanding loan after borrowing"
         );
+    }
+
+    /* Test: Function buyAndBorrow() and repay()
+        ├── Given a user has issuance tokens through buyAndBorrow
+           ├── And the user has an outstanding loan
+           └── And the user has sufficient orchestrator tokens for partial repayment
+               └── When the user repays a partial amount
+                   └── Then the outstanding loan should be reduced by the repayment amount
+    */
+    function testFuzzPublicBuyAndBorrow_succeedsValidRepayment(
+        uint leverage_,
+        uint collateralAmount_,
+        uint repaymentAmount_
+    ) public {
+        // Given: a user has issuance tokens
+        address user = makeAddr("user");
+        leverage_ = bound(leverage_, 1, lendingFacility.maxLeverage());
+
+        collateralAmount_ = bound(collateralAmount_, 1 ether, 100 ether);
+        testFuzzPublicBuyAndBorrow_succeedsGivenValidLeverage(
+            leverage_, collateralAmount_
+        );
+
+        uint outstandingLoan = lendingFacility.getOutstandingLoan(user);
+
+        repaymentAmount_ = bound(repaymentAmount_, 1, outstandingLoan);
+        orchestratorToken.mint(user, repaymentAmount_); // Mint the repaymentAmount_ to user to pay the outstandingLoan
+
+        vm.startPrank(user);
+        orchestratorToken.approve(address(fmBcDiscrete), type(uint).max);
+        orchestratorToken.approve(address(lendingFacility), type(uint).max);
+        issuanceToken.approve(address(lendingFacility), type(uint).max);
+
+        lendingFacility.repay(repaymentAmount_);
+        vm.stopPrank();
+
+        assertEq(
+            lendingFacility.getOutstandingLoan(user),
+            outstandingLoan - repaymentAmount_
+        );
+    }
+
+    /* Test: Function buyAndBorrow() and repay()
+        ├── Given a user has issuance tokens through buyAndBorrow
+           ├── And the user has an outstanding loan
+           └── And the user has sufficient orchestrator tokens for full repayment
+               └── When the user repays the full outstanding loan amount
+                   └── Then the outstanding loan should be zero
+    */
+    function testFuzzPublicBuyAndBorrow_succeedsValidFullRepayment(
+        uint leverage_,
+        uint collateralAmount_
+    ) public {
+        // Given: a user has issuance tokens
+        address user = makeAddr("user");
+        leverage_ = bound(leverage_, 1, lendingFacility.maxLeverage());
+
+        collateralAmount_ = bound(collateralAmount_, 1 ether, 100 ether);
+        testFuzzPublicBuyAndBorrow_succeedsGivenValidLeverage(
+            leverage_, collateralAmount_
+        );
+
+        uint outstandingLoan = lendingFacility.getOutstandingLoan(user);
+
+        orchestratorToken.mint(user, outstandingLoan); // Mint the outstandingLoan to user to pay the Full Loan
+
+        vm.startPrank(user);
+        orchestratorToken.approve(address(fmBcDiscrete), type(uint).max);
+        orchestratorToken.approve(address(lendingFacility), type(uint).max);
+        issuanceToken.approve(address(lendingFacility), type(uint).max);
+
+        lendingFacility.repay(outstandingLoan);
+        vm.stopPrank();
+
+        assertEq(lendingFacility.getOutstandingLoan(user), 0);
     }
 
     // =========================================================================

--- a/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_Lending_Facility_v1_Test.t.sol
@@ -415,7 +415,6 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         lendingFacility.setIndividualBorrowLimit(maxBorrowableQuota);
 
         borrowAmount_ = bound(borrowAmount_, 1, maxBorrowableQuota);
-        uint maxRepayAmount = borrowAmount_;
         repayAmount_ = bound(repayAmount_, 1, borrowAmount_);
         uint borrowAmount = borrowAmount_;
         uint repayAmount = repayAmount_;
@@ -957,12 +956,10 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         feeParams = helper_setDynamicFeeCalculatorParams(feeParams);
 
         // When: the user borrows collateral tokens
-        uint userBalanceBefore = orchestratorToken.balanceOf(user);
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
         // Then: the outstanding loan should equal the requested amount (fee on top model)
-        uint userBalanceAfter = orchestratorToken.balanceOf(user);
         uint outstandingLoan = lendingFacility.getOutstandingLoan(user);
 
         assertEq(
@@ -995,6 +992,56 @@ contract LM_PC_Lending_Facility_v1_Test is ModuleTest {
         lendingFacility.borrow(borrowAmount);
 
         // Then: the transaction should revert with InvalidBorrowAmount error
+    }
+
+    // =========================================================================
+    // Test: Buy and Borrow
+
+    function testPublicBuyAndBorrow_succeedsGivenValidLeverage() public {
+        // Given: a user has issuance tokens
+        address user = makeAddr("user");
+        orchestratorToken.mint(user, 100 ether);
+
+        fmBcDiscrete.openBuy();
+
+        // Record initial state
+        uint userCollateralBalanceBefore = orchestratorToken.balanceOf(user);
+        uint userIssuanceBalanceBefore = issuanceToken.balanceOf(user);
+        uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
+
+        vm.startPrank(user);
+        orchestratorToken.approve(address(fmBcDiscrete), type(uint).max);
+        orchestratorToken.approve(address(lendingFacility), type(uint).max);
+        issuanceToken.approve(address(fmBcDiscrete), type(uint).max);
+        issuanceToken.approve(address(lendingFacility), type(uint).max);
+
+        lendingFacility.buyAndBorrow(25);
+        vm.stopPrank();
+
+        // Then: verify state changes
+        // User should have received issuance tokens from the buy operation
+        uint userIssuanceBalanceAfter = issuanceToken.balanceOf(user);
+        assertGt(
+            userIssuanceBalanceAfter,
+            userIssuanceBalanceBefore,
+            "User should receive issuance tokens from buy operation"
+        );
+
+        // User should have some collateral remaining (less than initial amount due to fees and purchases)
+        uint userCollateralBalanceAfter = orchestratorToken.balanceOf(user);
+        assertLt(
+            userCollateralBalanceAfter,
+            userCollateralBalanceBefore,
+            "User should have spent some collateral on purchases"
+        );
+
+        // User should have an outstanding loan
+        uint outstandingLoanAfter = lendingFacility.getOutstandingLoan(user);
+        assertGt(
+            outstandingLoanAfter,
+            outstandingLoanBefore,
+            "User should have an outstanding loan after borrowing"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## buyAndBorrow Function Summary

The `buyAndBorrow` function is a newly added leveraged trading feature that allows users to buy issuance tokens and borrow against them in a single transaction. Users specify a leverage multiplier (1 to maxLeverage), and the function iteratively uses their collateral to purchase issuance tokens from the bonding curve, then automatically borrows against those locked tokens. This creates an efficient way to amplify both token acquisition and borrowing power simultaneously.

**Key Features:**
- **Leverage-based**: Users can multiply their buying and borrowing power up to a configurable maximum
- **Single transaction**: Combines token purchase and borrowing in one atomic operation
- **Automatic token locking**: Issuance tokens are automatically locked as collateral for loans
- **Iterative execution**: Processes leverage in loops, using all available collateral in each iteration
- **Integrated borrowing**: Leverages existing borrow() function with all its safety checks and limits

**Configuration & Security:**
- Maximum leverage controlled by `maxLeverage` state variable (configurable by authorized managers)
- Emits `BuyAndBorrowCompleted` event for transparency
- Includes comprehensive error handling for edge cases like insufficient collateral or zero token returns